### PR TITLE
TextInput now has "large", "borderless" and "centered" attrs

### DIFF
--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -1,7 +1,9 @@
 import styled from 'styled-components/native';
 import TouchableComponent from '../Touchable';
+import Typography from '../Typography';
 import { getTheme } from '../../utils/helpers';
 
+const disabled = getTheme('disabled');
 const primaryMain = getTheme('primary.main');
 const secondaryMain = getTheme('secondary.main');
 const primaryContrast = getTheme('primary.contrast');
@@ -22,14 +24,13 @@ interface ButtonWrapperProps {
 }
 
 export const ButtonWrapper = styled.View<ButtonWrapperProps>`
-  height: 42px;
+  height: 46px;
   flex-direction: row;
-  border: 2px solid;
   align-items: center;
   margin-vertical: 6px;
   min-width: 180px;
   padding: ${(props): string => (props.rounded ? '0' : '10px 11px')};
-  border-radius: ${(props): string => (props.rounded ? '50px' : '24px')}
+  border-radius: ${(props): string => (props.rounded ? '50px' : '8px')}
   justify-content: center;
   background-color: ${(props): string =>
     props.terciary
@@ -37,7 +38,7 @@ export const ButtonWrapper = styled.View<ButtonWrapperProps>`
       : props.secondary
       ? secondaryMain(props)
       : props.disabled
-      ? primaryDark(props)
+      ? disabled(props)
       : primaryMain(props)};
   border-color: ${(props): string =>
     props.terciary
@@ -52,7 +53,10 @@ interface TextButtonProps {
   secondary: boolean;
   disabled?: boolean;
 }
-export const TextButton = styled.Text<TextButtonProps>`
+export const TextButton = styled(Typography).attrs({ variant: 'headline' })<
+  TextButtonProps
+>`
+  letter-spacing: 0.4px;
   color: ${(props): string =>
     props.secondary
       ? primaryMain(props)

--- a/src/components/DatePicker/styles.ts
+++ b/src/components/DatePicker/styles.ts
@@ -12,10 +12,10 @@ const primaryDark = getTheme('primary.dark');
 const secondaryDark = getTheme('disabled');
 const inputMainColor = (props: { dark: any }): any =>
   getStatusStyle({
-    [InputStatus.SUCCESS]: getTheme('success'),
-    [InputStatus.FAILURE]: getTheme('failure'),
-    [InputStatus.DEFAULT]: props.dark ? primaryDark : primaryContrast,
-    [InputStatus.DISABLED]: secondaryDark,
+    [InputStatus.Success]: getTheme('success'),
+    [InputStatus.Failure]: getTheme('failure'),
+    [InputStatus.Default]: props.dark ? primaryDark : primaryContrast,
+    [InputStatus.Disabled]: secondaryDark,
   });
 
 export const LABEL_UPPER_STYLE = {

--- a/src/components/FormError/index.tsx
+++ b/src/components/FormError/index.tsx
@@ -4,18 +4,25 @@ import { ErrorText } from './styles';
 import { ThemeContext } from '../ThemeContext';
 
 interface Props {
-  error: string | boolean | undefined;
-  children?: JSX.Element | JSX.Element[];
+  centered?: boolean;
+  error?: string | string[];
   style?: object[];
 }
 
-const FormError: FC<Props> = ({ error = '', children, style }) => {
+const FormError: FC<Props> = ({
+  error = '',
+  centered = false,
+  children,
+  style,
+}) => {
   const { theme } = useContext(ThemeContext);
   return (
     <ThemeProvider theme={theme}>
       <>
         {children}
-        <ErrorText style={style}>{error}</ErrorText>
+        <ErrorText centered={centered} style={style}>
+          {error}
+        </ErrorText>
       </>
     </ThemeProvider>
   );

--- a/src/components/FormError/styles.ts
+++ b/src/components/FormError/styles.ts
@@ -1,8 +1,15 @@
 import styled from 'styled-components/native';
-import { getTheme } from '../../utils/helpers';
+import Typography from '../Typography';
+import { getTheme, ifStyle } from '../../utils/helpers';
 
-export const ErrorText = styled.Text`
-  min-height: 17px;
+const isCentered = ifStyle('centered');
+
+interface ErrorTextProps {
+  centered: boolean;
+}
+export const ErrorText = styled(Typography)<ErrorTextProps>`
   color: ${getTheme('failure')};
-  margin-top: 5px;
+  margin-top: ${getTheme('smallSpacing')};
+  text-align: ${isCentered('center', 'start')};
+  min-height: 25px;
 `;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -23,8 +23,8 @@ interface Props extends TouchableType {
 
 export const Icon: FC<Props> = ({
   id,
-  name,
   accessibility,
+  name = '',
   touchable = true,
   size = 20,
   color = undefined,

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -6,7 +6,7 @@ import Touchable from '../Touchable';
 import { ThemeContext } from '../ThemeContext';
 
 interface Props extends TouchableType {
-  children: string;
+  children: string | string[];
   variant?: Variants;
 }
 

--- a/src/components/Shadow/index.tsx
+++ b/src/components/Shadow/index.tsx
@@ -10,11 +10,7 @@ const shadowStyle = {
   width: '100%',
 };
 
-interface Props {
-  children: JSX.Element;
-}
-
-const Shadow: FC<Props> = ({ children }) => (
+const Shadow: FC = ({ children }) => (
   <View style={shadowStyle}>{children}</View>
 );
 

--- a/src/components/TextInput/MaskedTextInput/index.tsx
+++ b/src/components/TextInput/MaskedTextInput/index.tsx
@@ -1,26 +1,23 @@
-import React, { FC, useContext } from 'react';
-import { ThemeProvider } from 'styled-components';
+import React, { FC } from 'react';
 import { MaskedTextInput as MaskedTextInputType } from '../../../utils/types';
-import { ThemeContext } from '../../ThemeContext';
 import { TextInput } from './styles';
 
 const MaskedTextInput: FC<MaskedTextInputType> = ({
   maskType,
-  dark = false,
+  inputRef,
+  contrast = false,
   multiline = false,
   ...props
 }) => {
-  const { theme } = useContext(ThemeContext);
   return (
-    <ThemeProvider theme={theme}>
-      <TextInput
-        {...props}
-        dark={dark}
-        multiline={multiline}
-        type={maskType}
-        underlineColorAndroid="transparent"
-      />
-    </ThemeProvider>
+    <TextInput
+      {...props}
+      ref={inputRef}
+      contrast={contrast}
+      multiline={multiline}
+      type={maskType}
+      underlineColorAndroid="transparent"
+    />
   );
 };
 

--- a/src/components/TextInput/MaskedTextInput/styles.ts
+++ b/src/components/TextInput/MaskedTextInput/styles.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components/native';
 import { TextInputMask } from 'react-native-masked-text';
-
 import { TextInput as TextInputStyle } from '../styles';
 
 const Input = TextInputStyle.withComponent(TextInputMask);

--- a/src/components/TextInput/PasswordInput/index.tsx
+++ b/src/components/TextInput/PasswordInput/index.tsx
@@ -1,12 +1,9 @@
-import React, { useState, FC, useCallback, useContext } from 'react';
-import { ThemeProvider } from 'styled-components';
+import React, { useState, FC, useCallback } from 'react';
 import { TextInput as TextInputType } from '../../../utils/types';
 import TextInput from '../index';
-import { ThemeContext } from '../../ThemeContext';
 
 const PasswordInput: FC<TextInputType> = (props) => {
   const [hidePassword, setHidePassword] = useState<boolean>(true);
-  const { theme } = useContext(ThemeContext);
   const hitSlop = {
     left: 40,
     right: 40,
@@ -19,16 +16,14 @@ const PasswordInput: FC<TextInputType> = (props) => {
   }, [hidePassword]);
 
   return (
-    <ThemeProvider theme={theme}>
-      <TextInput
-        secureTextEntry={hidePassword}
-        iconName={hidePassword ? 'eye' : 'eye-off'}
-        iconTouchableEnabled
-        onPressIcon={onPressShowPassword}
-        iconHitSlop={hitSlop}
-        {...props}
-      />
-    </ThemeProvider>
+    <TextInput
+      secureTextEntry={hidePassword}
+      iconName={hidePassword ? 'eye' : 'eye-off'}
+      iconTouchableEnabled
+      onPressIcon={onPressShowPassword}
+      iconHitSlop={hitSlop}
+      {...props}
+    />
   );
 };
 

--- a/src/components/TextInput/styles.ts
+++ b/src/components/TextInput/styles.ts
@@ -8,32 +8,39 @@ interface InputAreaWrapperProps {
 }
 
 interface BottomLineProps {
-  dark?: boolean;
-  status?: string;
+  contrast: boolean;
+  status: string;
 }
 
+const normalTextSize = 16;
+const bigTextSize = 24;
+
 const isMultiline = ifStyle('multiline');
+const isCentered = ifStyle('centered');
+const isLarge = ifStyle('large');
+const hasLabel = ifStyle('label');
+const isContrast = ifStyle('contrast');
 const switchStatus = switchStyle('status');
 const primaryContrast = getTheme('primary.contrast');
 const primaryDark = getTheme('primary.dark');
 const success = getTheme('success');
 const failure = getTheme('failure');
 const disabled = getTheme('disabled');
-const inputColor = (props: BottomLineProps): any =>
+const inputColor = (props: TextInputType | BottomLineProps): any =>
   switchStatus({
-    [InputStatus.SUCCESS]: success,
-    [InputStatus.FAILURE]: failure,
-    [InputStatus.DEFAULT]: props.dark ? primaryDark : primaryContrast,
-    [InputStatus.DISABLED]: disabled,
+    [InputStatus.Success]: success,
+    [InputStatus.Failure]: failure,
+    [InputStatus.Default]: isContrast(primaryContrast, primaryDark)(props),
+    [InputStatus.Disabled]: disabled,
   });
 
 export const LABEL_UPPER_STYLE = {
-  top: 8,
+  top: -10,
   fontSize: 14,
 };
 
 export const LABEL_LOWER_STYLE = {
-  top: 40,
+  top: 20,
   fontSize: 18,
 };
 
@@ -42,28 +49,20 @@ interface WrapperProps {
 }
 
 export const Wrapper = styled.View<WrapperProps>`
-  height: ${isMultiline('auto', '89px')};
-  max-height: ${isMultiline('auto', '89px')};
-  min-height: ${isMultiline('89px', 'auto')};
+  height: ${hasLabel(isMultiline('auto', '89px'), isMultiline('auto', '32px'))};
+  max-height: ${hasLabel(
+    isMultiline('auto', '89px'),
+    isMultiline('auto', '32px'),
+  )};
+  min-height: ${hasLabel(
+    isMultiline('89px', 'auto'),
+    isMultiline('auto', '32px'),
+  )};
+  justify-content: ${hasLabel('flex-end', 'flex-start')};
   padding-top: 8px;
   position: relative;
-  justify-content: flex-end;
+  justify-content: ${hasLabel('flex-end', 'flex-start')};
 `;
-
-interface TextLabelProps {
-  dark: boolean;
-  status: string;
-  isPlaceholder: boolean;
-}
-
-export const TextLabel = styled.Text<TextLabelProps>`
-  line-height: 19px;
-  position: absolute;
-  color: ${inputColor};
-  font-size: ${LABEL_LOWER_STYLE.fontSize}px;
-`;
-
-export const Label = Animated.createAnimatedComponent(TextLabel);
 
 export const InputAreaWrapper = styled.View<InputAreaWrapperProps>`
   margin-top: 6px;
@@ -73,15 +72,33 @@ export const InputAreaWrapper = styled.View<InputAreaWrapperProps>`
   max-height: ${isMultiline('auto', '24px')};
 `;
 
-export const TextInput = styled.TextInput<TextInputType>`
+export const TextLabel = styled.Text`
+  line-height: 20px;
+  position: absolute;
+  color: ${inputColor};
+  font-size: ${LABEL_LOWER_STYLE.fontSize}px;
+  top: ${LABEL_LOWER_STYLE.top}px;
+`;
+export const Label = Animated.createAnimatedComponent(TextLabel);
+
+export const TextInput = styled.TextInput.attrs((props: TextInputType) => ({
+  textAlign: isCentered('center', 'left')(props),
+  selectionColor: props.contrast
+    ? `${primaryContrast(props)}80`
+    : `${primaryDark(props)}80`,
+  placeholderTextColor: props.contrast
+    ? `${primaryContrast(props)}60`
+    : `${primaryDark(props)}60`,
+}))<TextInputType>`
   padding: 0;
   flex-grow: 1;
   border-width: 0;
   min-height: 24px;
-  margin-top: ${isMultiline('16px', '0px')};
-  max-height: ${isMultiline('150px', '24px')};
   font-weight: 700;
   color: ${inputColor};
+  margin-top: ${isMultiline('16px', '0px')};
+  max-height: ${isMultiline('150px', '24px')};
+  font-size: ${isLarge(bigTextSize, normalTextSize)}px;
 `;
 
 export const BottomLine = styled.View<BottomLineProps>`

--- a/src/utils/types/InputStatus.ts
+++ b/src/utils/types/InputStatus.ts
@@ -1,6 +1,6 @@
 export enum InputStatus {
-  SUCCESS = 'SUCCESS',
-  FAILURE = 'FAILURE',
-  DEFAULT = 'DEFAULT',
-  DISABLED = 'DISABLED',
+  Success = 'SUCCESS',
+  Failure = 'FAILURE',
+  Default = 'DEFAULT',
+  Disabled = 'DISABLED',
 }

--- a/src/utils/types/TextInput.ts
+++ b/src/utils/types/TextInput.ts
@@ -1,69 +1,32 @@
+import { TextInputProps, StyleProp, TextStyle } from 'react-native';
 import { TextInputMaskTypeProp } from 'react-native-masked-text';
 
-type KeyboardType =
-  | 'default'
-  | 'url'
-  | 'numeric'
-  | 'email-address'
-  | 'phone-pad'
-  | 'visible-password'
-  | 'ascii-capable'
-  | 'numbers-and-punctuation'
-  | 'number-pad'
-  | 'name-phone-pad'
-  | 'decimal-pad'
-  | 'twitter'
-  | 'web-search'
-  | undefined;
-
-type ReturnKeyType =
-  | 'default'
-  | 'none'
-  | 'search'
-  | 'send'
-  | 'done'
-  | 'go'
-  | 'next'
-  | 'previous'
-  | 'google'
-  | 'join'
-  | 'route'
-  | 'yahoo'
-  | 'emergency-call'
-  | undefined;
-
-type MaskedInput = {
-  maskType: TextInputMaskTypeProp;
-};
-export interface TextInput {
+export interface TextInput extends TextInputProps {
   id: string;
   accessibility: string;
-  dark?: boolean;
-  multiline?: boolean;
-  secureTextEntry?: boolean;
-  autoComplete?: string;
-  keyboardType?: KeyboardType;
-  returnKeyType?: ReturnKeyType;
-  autoFocus?: boolean;
+  inputRef?: any;
+  options?: any;
+  large?: boolean;
+  borderless?: boolean;
+  contrast?: boolean;
+  centered?: boolean;
   iconSize?: number;
   iconTouchableEnabled?: boolean;
+  textStyle?: StyleProp<TextStyle>;
+  maskType?: TextInputMaskTypeProp;
   label?: string;
-  value?: string;
-  placeholder?: string;
-  iconName?: string | null;
-  maskType?: TextInputMaskTypeProp | null;
+  iconName?: string;
   status?: string;
-  error?: string | boolean;
+  error?: string;
   iconHitSlop?: object;
-  style?: any;
-  textStyle?: any;
   labelStyle?: any;
   isPlaceholder?: boolean;
   onPressIcon?(x?: any): void;
   onBlur?(x?: any): void;
   onFocus?(x?: any): void;
-  onChangeText?(x?: any): void;
   onSubmitEditing?(x?: any): void;
 }
 
-export type MaskedTextInput = TextInput & MaskedInput;
+export interface MaskedTextInput extends TextInput {
+  maskType: TextInputMaskTypeProp;
+}

--- a/src/utils/types/Typography.ts
+++ b/src/utils/types/Typography.ts
@@ -1,10 +1,11 @@
+import { StyleProp, TextStyle } from 'react-native';
 import { Variants } from './Variants';
 import { Theme } from './Theme';
 
 export interface Typography {
   variant?: Variants;
   children?: string | string[] | any;
-  style?: any;
+  style?: StyleProp<TextStyle>;
   textRef?: any;
   theme: Theme;
 }


### PR DESCRIPTION
## Descrição do PR

`large` aumenta o tamanho do input, `borderless` remove a borda inferior, `centered`, centraliza o texto e a mensagem de erro.

Também foram melhorados os types.

## Screenshots e GIFs

Os prints são da tela da bemol, mas tá mostrando o input com `borderless`, `large` e `centered` aplicado.

![image](https://user-images.githubusercontent.com/6873880/76122747-96bf1780-5fd5-11ea-9d54-181966cb62c0.png)
![image](https://user-images.githubusercontent.com/6873880/76122785-b1918c00-5fd5-11ea-9df0-cdd1849b03ac.png)

## Tipo de mudança

- [X] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [X] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)

## Checklist 🚨

- [ ] Meu código foi feito utilizando TDD (**testes unitários obrigatórios**)
- [ ] Meu código segue o code style da Builders.
- [ ] Testado no IOS
- [ ] Testado no Android

